### PR TITLE
caddyext now exits with status code 1 if there's an error.

### DIFF
--- a/commands/errors.go
+++ b/commands/errors.go
@@ -10,5 +10,5 @@ import (
 func cmdError(cmd *cobra.Command, err error) {
 	fmt.Printf("\n`caddyext %s` error: %s\n", cmd.Name(), err)
 	cmd.Usage()
-	os.Exit(0)
+	os.Exit(1)
 }


### PR DESCRIPTION
Using a non-zero exit code when there’s an error lets users create automated builds (i.e. Docker images). If the exit status is `0` upon error, it’s much more difficult to diagnose problems.